### PR TITLE
Add multi-agent codexBurst runner

### DIFF
--- a/src/agents/Aletheia.js
+++ b/src/agents/Aletheia.js
@@ -1,0 +1,8 @@
+export const Aletheia = {
+  name: () => 'Aletheia',
+  async execute(...args) {
+    console.log('[📖 Aletheia] Executing with args:', args.join(' '));
+    // TODO: implement truth-revealing logic for Codex
+    return '✨ Aletheia reveals a forgotten truth.';
+  },
+};

--- a/src/agents/CursorKitten.js
+++ b/src/agents/CursorKitten.js
@@ -1,0 +1,8 @@
+export const CursorKitten = {
+  name: () => 'CursorKitten',
+  async execute(...args) {
+    console.log('[🐾 CursorKitten] Executing with args:', args.join(' '));
+    // TODO: integrate CursorKitten logic
+    return '✨ CursorKitten purrs through the code.';
+  },
+};

--- a/src/agents/Phantom.js
+++ b/src/agents/Phantom.js
@@ -1,0 +1,8 @@
+export const Phantom = {
+  name: () => 'Phantom',
+  async execute(...args) {
+    console.log('[👻 Phantom] Executing with args:', args.join(' '));
+    // TODO: implement stealth operations
+    return '✨ Phantom fades into the shadows.';
+  },
+};

--- a/src/agents/Serafina.js
+++ b/src/agents/Serafina.js
@@ -1,0 +1,8 @@
+export const Serafina = {
+  name: () => 'Serafina',
+  async execute(...args) {
+    console.log('[🎶 Serafina] Executing with args:', args.join(' '));
+    // TODO: implement outreach and harmony logic
+    return '✨ Serafina sings a message of hope.';
+  },
+};

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -5,13 +5,14 @@ const args = process.argv.slice(2);
 const command = args[0];
 const envArg = args.find(a => a.startsWith('--env='));
 const env = envArg ? envArg.split('=')[1] : 'dev';
+const extraArgs = args.filter((a, i) => i > 0 && !a.startsWith('--env='));
 
 switch (command) {
   case 'burst':
-    codexBurst(env);
+    codexBurst(env, ...extraArgs);
     break;
   case 'update':
-    codexBurst(env);
+    codexBurst(env, ...extraArgs);
     break;
   default:
     console.log('Usage: ns <burst|update> [--env=dev]');

--- a/src/codex/codexBurst.js
+++ b/src/codex/codexBurst.js
@@ -1,4 +1,7 @@
-import { CursorKitten } from '../../NovaSanctum/src/codex/agents/CursorKitten.js';
+import { CursorKitten } from '../agents/CursorKitten.js';
+import { Aletheia } from '../agents/Aletheia.js';
+import { Serafina } from '../agents/Serafina.js';
+import { Phantom } from '../agents/Phantom.js';
 import fs from 'fs';
 import path from 'path';
 
@@ -10,14 +13,38 @@ function log(message) {
   fs.appendFileSync(logPath, entry);
 }
 
-export async function codexBurst(env = 'dev') {
-  const startMsg = `[💥 CodexBurst] Firing ${CursorKitten.name} in ${env}...`;
+const AGENTS = {
+  dev: CursorKitten,
+  enlighten: Aletheia,
+  outreach: Serafina,
+  stealth: Phantom,
+};
+
+export async function codexBurst(...args) {
+  console.log('[🐾 codexBurst] invoked with args:', args.join(' '));
+
+  const env = args[0];
+  const extraArgs = args.slice(1);
+
+  const agent = AGENTS[env];
+
+  if (!agent) {
+    console.log(`🚫 No agent configured for env: ${env}`);
+    return;
+  }
+
+  const startMsg = `[💥 CodexBurst] Firing ${agent.name()} in ${env}...`;
   console.log(startMsg);
   log(startMsg);
 
-  const result = await CursorKitten.execute();
-
-  const endMsg = `[✅ ${CursorKitten.name}] ${result}`;
-  console.log(endMsg);
-  log(endMsg);
+  try {
+    const result = await agent.execute(...extraArgs);
+    const endMsg = `[✅ ${agent.name()}] ${result}`;
+    console.log(endMsg);
+    log(endMsg);
+  } catch (err) {
+    const errMsg = `[❌ ${agent.name()}] ${err}`;
+    console.error(errMsg);
+    log(errMsg);
+  }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -1,8 +1,10 @@
 import { initEidolonCore } from '../src/modules/EidolonCore/index.js';
 import { initGameDin } from '../src/modules/GameDin/index.js';
 import { initSovereign } from '../src/modules/Sovereign/index.js';
+import { codexBurst } from '../src/codex/codexBurst.js';
 
 initEidolonCore();
 initGameDin();
 initSovereign();
+await codexBurst('dev', 'test-arg');
 console.log('Tests ran');


### PR DESCRIPTION
## Summary
- add new `agents` folder with CursorKitten, Aletheia, Serafina, Phantom
- update `codexBurst.js` to select agents by env arg and execute with extra args
- update CLI to forward extra args
- exercise codexBurst in tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68774c6ff35c8325a2ed219881a80261